### PR TITLE
Do not check or display non "web tool" type tools

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,7 +22,8 @@ def index():
     sort_by = request.args.get("sort_by", "title")  
     order = request.args.get("order", "asc") 
 
-    tools = session.query(Tool).all()
+    # Fetch all tools from the database, excluding the ones that are not web tools
+    tools = session.query(Tool).filter(Tool.web_tool == True).all()
 
     # Sorting tools by title after normalizing (removing non-alphanumeric characters from the start and stripping spaces)
     if sort_by == "title":

--- a/model.py
+++ b/model.py
@@ -22,6 +22,7 @@ class Tool(Base):
     license = Column(Text)
     technology_used = Column(Text)
     bugtracker_url = Column(Text)
+    web_tool = Column(Boolean, default=False)
     health_status = Column(Boolean, default=False)
     last_checked = Column(TIMESTAMP, default=datetime.datetime.now)
     page_num = Column(Integer)


### PR DESCRIPTION
- Add column `web_tool` (bool)
- Use `tool_type` to set that to True if the tool is a `web tool`
- Only return web tools when querying the database
- Move getting URL/checking uptime/writing to db into the same for loop

**Note:** This change will require the tool database to be regenerated.

Bug: [T376451](https://phabricator.wikimedia.org/T376451)