### PR TITLE
Update toolforge-update.sh

### DIFF
--- a/scripts/toolforge-update.sh
+++ b/scripts/toolforge-update.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 toolforge build start https://github.com/gopavasanth/ToolWatch
-toolforge webservice python3.11 restart
+toolforge webservice --mount=none buildservice start
 toolforge jobs load jobs.yaml


### PR DESCRIPTION
Since our tool is buildservice based, it should use the buildservice command to restart the tool, not the python3.11 one